### PR TITLE
feat: added union to enable both float and int arguments for sum function

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -9,8 +9,8 @@ def sum(a: Union[int, float], b: Union[int, float]) -> Union[int, float]:
     This function returns the sum of two numbers
 
     Args:
-    a: float the first number
-    b: float the second number
+    a: int, float the first number
+    b: int, float the second number
 
     Returns:
     float the sum of a and b

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,10 +1,10 @@
-from typing import Optional
+from typing import Optional, Union
 import numpy as np
 
 # TODO: make all functions work with strings as well
 # TODO: add a new cool calculator function
 
-def sum(a: int, b: int) -> int:
+def sum(a: Union[int, float], b: Union[int, float]) -> Union[int, float]:
     '''
     This function returns the sum of two numbers
 


### PR DESCRIPTION
# Description

Fixed the issue that the sum function was only working with floats.
I added this line to fix it
```
def sum(a: Union[int, float], b: Union[int, float]) -> Union[int, float]:
```

- resolves #1 

# Type of change
- **feat**: A new feature

# Features (Optional)
- importing Union
- added float to input arguments
- added float to output arguments

# Questions (Optional)
- Is there a better way to do it?
