### PR TITLE
fix: Made modulo more parsimonious. Changed return type from float to int

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -52,13 +52,10 @@ def modulo(a: int, b: int):
     b: int the divisor
 
     Returns:
-    float
+    int
     '''
 
-    # I think this could be made more efficient?
-    result = a - (np.floor(a / b) * b)
-
-    return result
+    return a % b
 
 def element_wise_multiply(a: np.array, b: np.array) -> np.array:
     '''


### PR DESCRIPTION
# Description
Python has a built-in modulo function- no need to reinvent the wheel

- resolves #2 

# Type of change

- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)



# Questions (Optional)
- Not sure if you want to take int or float arguments. Arguments are int, but perhaps you want to run the modulo with floats as well?

# Remarks (Optional)
- See Question
